### PR TITLE
feat: add choice to include comments with post query

### DIFF
--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -42,8 +42,11 @@ export class PostsController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.postsService.findOne({ id });
+  findOne(
+    @Param('id') id: string,
+    @Query('comments') includeComments?: boolean,
+  ) {
+    return this.postsService.findOne({ id }, { comments: includeComments });
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -30,10 +30,12 @@ export class PostsService {
 
   async findOne(
     postWhereUniqueInput: Prisma.PostWhereUniqueInput,
+    postInclude: Prisma.PostInclude,
   ): Promise<Post | null> {
     const post = await this.prismaService.post
       .findUnique({
         where: postWhereUniqueInput,
+        include: postInclude,
       })
       .catch(prismaQueryError);
 


### PR DESCRIPTION
**Feature: Query post with comments**
- Use ```comments``` query parameter and set it to ```true``` to include comments when fetching a single post